### PR TITLE
bug fix and add of plain text password

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BE_CFLAGS =
 BE_LDFLAGS =
 BE_LDADD =
 BE_DEPS =
-OBJS = auth-plug.o base64.o pbkdf2-check.o log.o envs.o hash.o be-psk.o backends.o cache.o
+OBJS = auth-plug.o base64.o pbkdf2-check.o plaintext-check.o log.o envs.o hash.o be-psk.o backends.o cache.o
 
 BACKENDS =
 BACKENDSTR =
@@ -169,6 +169,7 @@ be-mysql.o: be-mysql.c be-mysql.h Makefile
 be-ldap.o: be-ldap.c be-ldap.h Makefile
 be-sqlite.o: be-sqlite.c be-sqlite.h Makefile
 pbkdf2-check.o: pbkdf2-check.c base64.h Makefile
+plaintext-check.o: plaintext-check.c Makefile
 base64.o: base64.c base64.h Makefile
 log.o: log.c log.h Makefile
 envs.o: envs.c envs.h Makefile

--- a/README.md
+++ b/README.md
@@ -55,8 +55,17 @@ plugin as `auth_opt_anonusername` and they
 are handled by a so-called _fallback back-end_ which is the *first* configured
 back-end.
 
-Passwords are obtained from the back-end as PBKDF2 strings (see [Passwords](#passwords) below). If you store a clear-text password or any hash not generated the same way,
+Passwords are obtained from the back-end as PLAINTEXT string or as PBKDF2 
+strings (see [Passwords](#passwords) below). 
+The option `auth_opt_passwd_method` fix the comparison method.
+PBKDF2 is used by default (or with the value `pbkdf2` put to this option),
+if you store a clear-text password or any hash not generated the same way,
 the comparison and the authentication will fail.
+If you want to store clear-text password, you must add the value `plaintext` as :
+
+```
+auth_opt_passwd_method plaintext
+```
 
 The mysql and mongo back-ends support expansion of `%c` and `%u` as clientid and username
 respectively. This allows ACLs in the database to look like this:
@@ -748,9 +757,9 @@ mysql> INSERT INTO user (username, pwhash, superuser) VALUES ('mylistener', 'F0B
 
 ## Passwords
 
-A user's password is stored as a [PBKDF2] hash in the back-end. An example
-"password" is a string with five pieces in it, delimited by `$`, inspired by
-[this][1].
+By default, a user's password is stored as a [PBKDF2] hash in the back-end.
+An example "password" is a string with five pieces in it, delimited by `$`,
+inspired by [this][1].
 
 ```
 PBKDF2$sha256$901$8ebTR72Pcmjl3cYq$SCVHHfqn9t6Ev9sE6RMTeF3pawvtGqTu
@@ -768,6 +777,14 @@ base64 decoded before the validation). In case your own implementation uses
 the raw bytes when hashing the password and base64 is only used for display
 purpose, compile this project with the `-DRAW_SALT` flag (you could add this
 in the `config.mk` file to `CFG_CFLAGS`).
+
+A plaintext password may be used. In this case you must add in the file
+mosquitto.conf the following line :
+
+```
+auth_opt_passwd_method plaintext
+```
+
 
 ## Creating a user
 

--- a/auth-plug.c
+++ b/auth-plug.c
@@ -497,9 +497,10 @@ int mosquitto_auth_security_cleanup(void *userdata, struct mosquitto_auth_opt *a
 	return MOSQ_ERR_SUCCESS;
 }
 
-
-#if MOSQ_AUTH_PLUGIN_VERSION >=3
+#if MOSQ_AUTH_PLUGIN_VERSION >=4
 int mosquitto_auth_unpwd_check(void *userdata, struct mosquitto *client, const char *username, const char *password)
+#elif MOSQ_AUTH_PLUGIN_VERSION ==3
+int mosquitto_auth_unpwd_check(void *userdata, const struct mosquitto *client, const char *username, const char *password)
 #else
 int mosquitto_auth_unpwd_check(void *userdata, const char *username, const char *password)
 #endif
@@ -597,8 +598,10 @@ int mosquitto_auth_unpwd_check(void *userdata, const char *username, const char 
 	return granted;
 }
 
-#if MOSQ_AUTH_PLUGIN_VERSION >= 3
+#if MOSQ_AUTH_PLUGIN_VERSION >= 4
 int mosquitto_auth_acl_check(void *userdata, int access, struct mosquitto *client, const struct mosquitto_acl_msg *msg)
+#elif MOSQ_AUTH_PLUGIN_VERSION == 3
+int mosquitto_auth_acl_check(void *userdata, int access, const struct mosquitto *client, const struct mosquitto_acl_msg *msg)
 #else
 int mosquitto_auth_acl_check(void *userdata, const char *clientid, const char *username, const char *topic, int access)
 #endif
@@ -748,8 +751,10 @@ int mosquitto_auth_acl_check(void *userdata, const char *clientid, const char *u
 }
 
 
-#if MOSQ_AUTH_PLUGIN_VERSION >= 3
+#if MOSQ_AUTH_PLUGIN_VERSION >= 4
 int mosquitto_auth_psk_key_get(void *userdata, struct mosquitto *client, const char *hint, const char *identity, char *key, int max_key_len)
+#elif MOSQ_AUTH_PLUGIN_VERSION == 3
+int mosquitto_auth_psk_key_get(void *userdata, const struct mosquitto *client, const char *hint, const char *identity, char *key, int max_key_len)
 #else
 int mosquitto_auth_psk_key_get(void *userdata, const char *hint, const char *identity, char *key, int max_key_len)
 #endif

--- a/plaintext-check.c
+++ b/plaintext-check.c
@@ -1,0 +1,6 @@
+#include <string.h>
+
+int plaintext_check(char *password, char *hash) {
+  return (strcmp(password,hash)==0) ;
+}
+


### PR DESCRIPTION
First, after adding support for version 1.6.2 of mosquitto, earlier versions using MOSQ_AUTH_PLUGIN_VERSION 3 no longer compiled.

Next, add the possibility to choose (with the configuration in mosquitto.conf) between the storage of plain-text passwords and the storage of passwords encrypted by pbkdf2.

(_It seems that I'm not the only one who needs a plain-text password stored in a database like MySQL for some application_)

